### PR TITLE
感染者数予測の機能修正、感染者数検索にて機能追加

### DIFF
--- a/app/controllers/line_bot_controller.rb
+++ b/app/controllers/line_bot_controller.rb
@@ -45,7 +45,13 @@ class LineBotController < ApplicationController
       when Line::Bot::Event::MessageType::Location
         lat = event["message"]["latitude"]
         lng = event["message"]["longitude"]
-        message = access_google_places(lat, lng)
+        # message = access_google_places(lat, lng)
+        text = "現在、こちらの機能をご利用いただくことができません。"
+        message = {
+          type: 'text',
+          text: text
+        }
+
         client.reply_message(event['replyToken'], message)
       end
       userId = event['source']['userId']
@@ -97,37 +103,37 @@ class LineBotController < ApplicationController
       end
       client.reply_message(event['replyToken'], create_quick_reply_all)
 
-    # elsif event['message']['text'] == '将来の予測を確認する'
-    #   ### 体調チェック中にこのイベントが発火されたら、体調チェックを中断する
-    #   if @@count != 0 || @@is_checking == true
-    #     receive_unrelated_message_while_question(event, userId)
-    #     return
-    #   end
+    elsif event['message']['text'] == '将来の予測を確認する'
+      ### 体調チェック中にこのイベントが発火されたら、体調チェックを中断する
+      if @@count != 0 || @@is_checking == true
+        receive_unrelated_message_while_question(event, userId)
+        return
+      end
 
-    #   ### FIXME: コードの整理が必要
-    #   predict_total_positives = predict_future_positives.map{|hash| "#{hash["date"].to_s.slice(-4, 4)}, #{hash["positive"]}" }
-    #   first_days_last_days_for_a_week = []
+      ### FIXME: コードの整理が必要
+      predict_total_positives = predict_future_positives.map{|hash| "#{hash["date"].to_s.slice(-4, 4)}, #{hash["positive"]}" }
+      first_days_last_days_for_a_week = []
 
-    #   predict_total_positives.each_slice(7){|arr|
-    #     array = []
-    #     if arr.size == 7
-    #       array << arr.first.split(', ')
-    #       array << arr.last.split(', ')
+      predict_total_positives.each_slice(7){|arr|
+        array = []
+        if arr.size == 7
+          array << arr.first.split(', ')
+          array << arr.last.split(', ')
 
-    #       first_days_last_days_for_a_week << array
-    #     end
-    #   }
+          first_days_last_days_for_a_week << array
+        end
+      }
 
-    #   positives_each_week = first_days_last_days_for_a_week.map{ |first_day, last_day|
-    #     incremented_positive_num = last_day[1].to_i - first_day[1].to_i
-    #     first_day = first_day[0].insert(2, '/')
-    #     last_day = last_day[0].insert(2, '/')
+      positives_each_week = first_days_last_days_for_a_week.map{ |first_day, last_day|
+        incremented_positive_num = last_day[1].to_i - first_day[1].to_i
+        first_day = first_day[0].insert(2, '/')
+        last_day = last_day[0].insert(2, '/')
 
-    #     [first_day, last_day, incremented_positive_num]
-    #   }
+        [first_day, last_day, incremented_positive_num]
+      }
 
-    #   message = create_predict_flex(positives_each_week)
-    #   client.reply_message(event['replyToken'], message)
+      message = create_predict_flex(positives_each_week)
+      client.reply_message(event['replyToken'], message)
 
     elsif event['message']['text'] == '体調チェックをする' || event['message']['text'] == 'はい🙆‍♂️' || event['message']['text'] == 'いいえ🙅‍♂️'
       ### 体調チェック時以外の「はい🙆‍♂️」、「いいえ🙅‍♂️」はスルーする
@@ -186,6 +192,13 @@ class LineBotController < ApplicationController
 
       message = create_warning_prefecturs
       client.reply_message(event['replyToken'], message)
+
+    elsif event['message']['text'] == 'その他の都道府県を検索する'
+      if @@count != 0 || @@is_checking == true
+        receive_unrelated_message_while_question(event, userId)
+        return
+      end
+      client.reply_message(event['replyToken'], open_chat_button)
     else
       ### 体調チェック中にこのイベントが発火されたら、体調チェックを中断する
       if @@count != 0 || @@is_checking == true

--- a/lib/utils/corona_api_methods.rb
+++ b/lib/utils/corona_api_methods.rb
@@ -34,7 +34,7 @@ module CoronaApiMethods
   def quick_reply_prefs
     # ["北海道", "宮城県", "千葉県","東京都","神奈川県","石川県", "愛知県", "京都府","大阪府","兵庫県", "福岡県", "沖縄県"]
     ### 47都道府県のうち、ランダムで12都道府県を取り出して、表示するようにする
-    PREFECTURES.shuffle.slice(0, 13)
+    PREFECTURES.shuffle.slice(0, 12)
   end
 
   ### 直近３０日間の感染者数をユーザーに知らせるテキストメッセージを作成する
@@ -89,7 +89,8 @@ module CoronaApiMethods
 
   ### 将来30日の日本の感染者数の予測
   def predict_future_positives
-    uri = URI.parse("https://covid19-japan-web-api.now.sh/api/v1/total?predict=true")
+    params = URI.encode_www_form({predict: true})
+    uri = URI.parse("https://covid19-japan-web-api.vercel.app/api/v1/total?#{params}")
     access_api(uri)
   end
 
@@ -113,7 +114,15 @@ module CoronaApiMethods
 
   ### 全国のクイックリプライを用意する
   def create_quick_reply_all
-    items = []
+    # items = [ {"type": "action", "imageUrl": "", "action": { "type": "message", "label": "その他の都道府県を検索する", "text": "その他の都道府県を検索する"}}]
+    items = [ {"type": "action", "imageUrl": "",
+      "action": {
+        "type": "uri",
+        "label": "その他の都道府県を調べる",
+        "uri": "https://line.me/R/oaMessage/@777khyfa/"
+      }
+    }]
+    p items[0]
     quick_reply_prefs.each do |pref|
       items << {"type": "action", "imageUrl": "", "action": { "type": "message", "label": "#{pref}", "text": "#{pref}"}}
     end

--- a/lib/utils/flex_message.rb
+++ b/lib/utils/flex_message.rb
@@ -128,44 +128,44 @@ module FlexMessage
     contents
   end
 
-  # def create_predict_flex(array)
-  #   {
-  #     "type": "flex",
-  #     "altText": "今後30日間の感染者数の予測です。",
-  #     "contents": {
-  #       "type": "bubble",
-  #       "header": {
-  #         "type": "box",
-  #         "layout": "vertical",
-  #         "contents": [
-  #           {
-  #             "type": "text",
-  #             "text": "将来の感染者の予測",
-  #             "size": "lg",
-  #             "align": "center",
-  #             "wrap": true,
-  #             "adjustMode": "shrink-to-fit"
-  #           },
-  #           {
-  #             "type": "separator",
-  #             "margin": "md"
-  #           }
-  #         ]
-  #       },
-  #       "hero": {
-  #         "type": "box",
-  #         "layout": "vertical",
-  #         "contents": create_boxes(array),
-  #         "flex": 2
-  #       },
-  #       "body": {
-  #         "type": "box",
-  #         "layout": "vertical",
-  #         "contents": []
-  #       }
-  #     }
-  #   }
-  # end
+  def create_predict_flex(array)
+    {
+      "type": "flex",
+      "altText": "今後30日間の感染者数の予測です。",
+      "contents": {
+        "type": "bubble",
+        "header": {
+          "type": "box",
+          "layout": "vertical",
+          "contents": [
+            {
+              "type": "text",
+              "text": "将来の感染者の予測",
+              "size": "lg",
+              "align": "center",
+              "wrap": true,
+              "adjustMode": "shrink-to-fit"
+            },
+            {
+              "type": "separator",
+              "margin": "md"
+            }
+          ]
+        },
+        "hero": {
+          "type": "box",
+          "layout": "vertical",
+          "contents": create_boxes(array),
+          "flex": 2
+        },
+        "body": {
+          "type": "box",
+          "layout": "vertical",
+          "contents": []
+        }
+      }
+    }
+  end
 
 
   ### 「ヘルプ」が押された際に表示するflex message
@@ -605,6 +605,87 @@ module FlexMessage
                     "type": "uri",
                     "label": "位置情報を送信する",
                     "uri": "line://nv/location"
+                  },
+                  "margin": "none",
+                  "height": "sm",
+                  "style": "secondary",
+                  "adjustMode": "shrink-to-fit"
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  end
+
+  ### 位置情報送信ボタンを表示する
+  def open_chat_button
+    {
+      "type": "flex",
+      "altText": "位置情報ボタンです。",
+      "contents": {
+        "type": "carousel",
+        "contents": [
+          {
+            "type": "bubble",
+            "size": "mega",
+            "header": {
+              "type": "box",
+              "layout": "vertical",
+              "contents": [
+                {
+                  "type": "text",
+                  "text": "医療施設検索",
+                  "wrap": true,
+                  "adjustMode": "shrink-to-fit",
+                  "align": "center",
+                  "size": "lg"
+                },
+                {
+                  "type": "separator",
+                  "margin": "md"
+                }
+              ]
+            },
+            "hero": {
+              "type": "box",
+              "layout": "vertical",
+              "contents": [
+                {
+                  "type": "text",
+                  "text": "あなたの最寄りの医療施設を検索します。",
+                  "adjustMode": "shrink-to-fit",
+                  "wrap": true,
+                  "margin": "none",
+                  "size": "xs",
+                  "align": "center",
+                  "offsetStart": "none",
+                  "offsetEnd": "none"
+                },
+                {
+                  "type": "text",
+                  "text": "下記のボタンから位置情報を送信してください。",
+                  "align": "center",
+                  "wrap": true,
+                  "adjustMode": "shrink-to-fit",
+                  "size": "xs",
+                  "margin": "sm"
+                }
+              ],
+              "margin": "none"
+            },
+            "body": {
+              "type": "box",
+              "layout": "vertical",
+              "contents": [
+                {
+                  "type": "button",
+                  "action": {
+                    "type": "uri",
+                    "label": "チャットページを開く",
+                    "uri": "https://line.me/R/oaMessage/@777khyfa/"
+                    # "uri": "https://line.me/R/nv/chat"
                   },
                   "margin": "none",
                   "height": "sm",

--- a/lib/utils/google_api_methods.rb
+++ b/lib/utils/google_api_methods.rb
@@ -9,9 +9,9 @@ module GoogleApiMethods
   def access_google_places(lat, lng)
     rad = 5000
     types = "hospital"
-    url = "https://maps.googleapis.com/maps/api/place/nearbysearch/json?location=#{lat},#{lng}&radius=#{rad}&types=#{types}&sensor=false&language=ja&key=#{API_KEY}"
+    # url = "https://maps.googleapis.com/maps/api/place/nearbysearch/json?location=#{lat},#{lng}&radius=#{rad}&types=#{types}&sensor=false&language=ja&key=#{API_KEY}"
 
-    uri = URI.parse(url)
+    # uri = URI.parse(url)
 
     hospital_infos = []
     access_api(uri)['results'].map{ |hash|


### PR DESCRIPTION
### 機能修正について

- 感染者数の機能にてAPIを叩いている箇所で発生しているエラーを修正
- 目的地の感染者数を検索する箇所で、クイックリプライに載っていない都道府県を検索するためにメッセージ入力欄を表示させるボタンを追加